### PR TITLE
Refactored Device wrapping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ Icon
 venv
 build/
 dist/
+*.idea
 *.egg-info
 *.egg-info test
 *.pyc

--- a/src/exengine/backends/openwfs/__init__.py
+++ b/src/exengine/backends/openwfs/__init__.py
@@ -1,0 +1,22 @@
+from exengine.kernel.executor import DeviceBase
+from openwfs.utilities import get_pixel_size
+from queue import Queue
+
+class CameraSchema(DeviceBase):
+    def __init__(self, *args):
+        super().__init__(*args)
+        self._frames = Queue()
+
+    @staticmethod
+    def map_names(class_dict):
+        class_dict['exposure'] = class_dict.pop('duration')
+
+    def arm(self):
+        pass
+
+    def start(self):
+        self._frames.put(self._device.trigger())
+
+    def pop_data(self):
+        frame = self._frames.get().result()
+        return frame, {"pixel_size": get_pixel_size(frame)}

--- a/src/exengine/backends/openwfs/__init__.py
+++ b/src/exengine/backends/openwfs/__init__.py
@@ -3,8 +3,8 @@ from openwfs.utilities import get_pixel_size
 from queue import Queue
 
 class CameraSchema(DeviceBase):
-    def __init__(self, *args):
-        super().__init__(*args)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self._frames = Queue()
 
     @staticmethod

--- a/src/exengine/backends/openwfs/examples/simulated_microscope.py
+++ b/src/exengine/backends/openwfs/examples/simulated_microscope.py
@@ -1,0 +1,26 @@
+import numpy as np
+from openwfs.plot_utilities import imshow
+from openwfs.simulation import StaticSource, Microscope
+import astropy.units as u
+
+from exengine import ExecutionEngine
+from exengine.backends.openwfs import CameraSchema
+
+# construct a microscope with a random image
+img = (np.random.rand(100, 100) > 0.99) * 1.0
+pixel_size = 0.1 * u.micrometer
+specimen = StaticSource(img, pixel_size=pixel_size)
+microscope = Microscope(specimen, wavelength=0.5 * u.micrometer, numerical_aperture=0.8)
+
+engine = ExecutionEngine()
+camera = engine.register("camera", microscope, schema=CameraSchema)
+
+# test the start/pop_next protocol
+camera.arm() # does nothing, OpenWFS camera is always armed
+camera.start()
+frame, metadata = camera.pop_data()
+engine.shutdown()
+imshow(frame)
+input()
+
+

--- a/src/exengine/backends/openwfs/test/test_schema_translator.py
+++ b/src/exengine/backends/openwfs/test/test_schema_translator.py
@@ -1,0 +1,45 @@
+from queue import Queue
+
+from openwfs.simulation import StaticSource
+from openwfs.utilities import get_pixel_size
+from exengine import ExecutionEngine
+import astropy.units as u
+import numpy as np
+
+from exengine.kernel.executor import DeviceBase
+
+
+class CameraSchema(DeviceBase):
+    def __init__(self, *args):
+        super().__init__(*args)
+        self._frames = Queue()
+
+    @staticmethod
+    def map_names(class_dict):
+        class_dict['exposure'] = class_dict.pop('duration')
+
+    def start(self):
+        self._frames.put(self._device.trigger())
+
+    def pop_data(self):
+        frame = self._frames.get().result()
+        return frame, {"pixel_size": get_pixel_size(frame)}
+
+def test_schema():
+    # construct a camera with a random image
+    img = np.random.rand(100, 100)
+    pixel_size = 5 * u.micrometer
+    camera = StaticSource(img, pixel_size=pixel_size)
+    assert np.all(camera.read() == img)
+
+    # wrap in ExEngine
+    engine = ExecutionEngine()
+    camera = engine.register("camera", camera, schema=CameraSchema)
+
+    # test the start/pop_next protocol
+    camera.start()
+    frame, metadata = camera.pop_data()
+    print(camera.exposure) # test if the property is present
+    assert np.all(frame == img)
+    assert np.allclose(metadata["pixel_size"], pixel_size * np.ones((1,2)))
+    engine.shutdown()

--- a/src/exengine/backends/openwfs/test/test_schema_translator.py
+++ b/src/exengine/backends/openwfs/test/test_schema_translator.py
@@ -1,29 +1,10 @@
-from queue import Queue
-
-from openwfs.simulation import StaticSource
-from openwfs.utilities import get_pixel_size
 from exengine import ExecutionEngine
+from openwfs.simulation import StaticSource
 import astropy.units as u
 import numpy as np
 
-from exengine.kernel.executor import DeviceBase
+from exengine.backends.openwfs import CameraSchema
 
-
-class CameraSchema(DeviceBase):
-    def __init__(self, *args):
-        super().__init__(*args)
-        self._frames = Queue()
-
-    @staticmethod
-    def map_names(class_dict):
-        class_dict['exposure'] = class_dict.pop('duration')
-
-    def start(self):
-        self._frames.put(self._device.trigger())
-
-    def pop_data(self):
-        frame = self._frames.get().result()
-        return frame, {"pixel_size": get_pixel_size(frame)}
 
 def test_schema():
     # construct a camera with a random image
@@ -37,6 +18,7 @@ def test_schema():
     camera = engine.register("camera", camera, schema=CameraSchema)
 
     # test the start/pop_next protocol
+    camera.arm() # does nothing, OpenWFS camera is always armed
     camera.start()
     frame, metadata = camera.pop_data()
     print(camera.exposure) # test if the property is present

--- a/src/exengine/backends/openwfs/test/test_schema_translator.py
+++ b/src/exengine/backends/openwfs/test/test_schema_translator.py
@@ -1,8 +1,10 @@
 from exengine import ExecutionEngine
 from openwfs.simulation import StaticSource
+from openwfs.plot_utilities import imshow
+from openwfs.simulation.microscope import Microscope
 import astropy.units as u
 import numpy as np
-
+import matplotlib.pyplot as plt
 from exengine.backends.openwfs import CameraSchema
 
 

--- a/src/exengine/examples/complex_use_case.py
+++ b/src/exengine/examples/complex_use_case.py
@@ -1,0 +1,169 @@
+# This is pseodo-code for a complex experiment that uses the exengine package.
+# The same code is written in different forms to compare the readability and conciseness of the proposed api
+from typing import Iterable, Annotated, List
+
+# The code will show a live image of a three different cameras in the GUI, with the options to set properties like exposure time and gain
+# In addition, there will be a button with the text "Calibrate" that will trigger a calibration script when clicked
+# This calibration procedure is to move the XY stage by known distances and measure the distance moved using the cameras
+# The calibration script will then calculate the conversion factor between pixels and micrometers for each of the cameras
+
+import exengine
+import harvesters
+import openwfs
+import pymmcore
+import superstage
+from exengine import ExecutionEngine
+from exengine.interfaces import Camera, XYStage
+
+
+# The calibration script
+class CalibrationWidget:
+    """Widget for calibrating pixel sizes of cameras.
+
+    This widget demonstrates several concepts:
+    * The use of the Annotated type hint to specify units and constraints for properties.
+        ExEngine recognizes all public properties in the object and exposes them in the GUI.
+        The Annotated type hint is used to specify units and constraints for the properties.
+        These constraints are enforeced by ExEngine through the SetAttrEvent.
+    * The use of the exengine.annotate.gui decorator to add a button to the GUI.
+        The decorator takes the text of the button as an argument.
+        The button is grayed out when the CalibrationWidget object is busy.
+    * Storing device references (and lists thereof) as public attributes.
+        These attributes are displayed as special fields, and allow making connections between devices.
+        By specifying an interface type in the type hint, ExEngine can automatically validate
+        values for these attributes.
+    * Multi-device synchronization. The exengine.annotate.synchronized decorator indicates that
+        during execution of this function all devices should be locked.
+        Because of this decorator, the 'Calibrate' button is also grayed out when
+        any of the the child devices (camera or stage) is busy.
+    * Progress reporting. By requesting a '_progress' argument in any method, the engine
+        will automatically provide a callback object that can be used to report progress.
+        At every call to the 'update' method of this object, the progress bar in the GUI is updated.
+        This also allows the user to cancel the operation, resulting in an asyncio.CancelledError exception.
+    * Inter-object synchronization. In the call to 'run', the Widget *and all its child devices* are locked
+        and form a synchronization group. By default, all actuators in a synchronization group (the stage)
+        wait for all sensors (the cameras) to complete before starting to execute a command. Vice versa,
+        all sensors wait for all actuators to complete before starting to acquire data.
+    * Asynchronous programming. The 'capture' method of the camera returns a future.
+        Instead of storing the frames, the futures are stored in a list. In this case, all measurements may get
+        scheduled before the first one is completed.
+    * on_complete callbacks. The futures that are returned by 'capture' send an 'on_complete' signal that
+        we subscribe to in order to update the progress bar.
+    * User interaction through a modal dialog box. The 'question' method of the engine is used to ask
+        the user if the calibration results. For a text-base frontend, this will give a prompt in the console.
+    """
+    step_size: Annotated[float, Gt(0.0), Unit("um")]
+    step_count: Annotated[int, Gt(0)]
+    pixel_sizes: List[Annotated[float, Gt(0.0), Unit("um")]]
+    cameras: Annotated[List[exengine.interfaces.Camera]]
+    stage: Annotated[exengine.interfaces.XYStage]
+
+    def __init__(self, cameras: List[Camera], stage: XYStage):
+        self.step_size = 10.0
+        self.step_count = 10
+        self.cameras = cameras
+        self.stage = stage
+
+    @exengine.annotate.gui.button("Calibrate")
+    @exengine.annotate.synchronized(True)
+    def run(self, engine, /, *, _progress):
+        _progress.total = self.step_count * 2
+        _progress.description = "Calibrating camera magnifications"
+        for axis in ["x", "y"]:
+            all_images = []
+            start = getattr(stage, axis)
+            for i in range(10):
+                setattr(stage, axis, start + i * self.step_size)
+                frames = [camera.capture() for camera in cameras]
+                frames[-1].on_complete.append(lambda: _progress.update(1))
+                all_images.append(frames)
+
+        # analyze the images
+        ...
+
+        # update pixels sizes on the cameras
+        report = f"Calibration complete. Pixel sizes:\n"
+        for camera, pixel_size in zip(self.cameras, self.pixel_sizes):
+            report += f"\nCamera {camera.name}: {pixel_size} um\n"
+        report += f"\nApply these values to the cameras?"
+        if engine.gui.question("Calibration complete", report):
+            for camera, pixel_size in zip(self.cameras, self.pixel_sizes):
+                camera.pixel_size = pixel_size
+
+
+
+# for the stage, we need to write our own wrapper:
+class SuperStageWrapper(superstage.DualAxisStage):
+    """Wrapper for a hypothetical stage that has two axes
+
+    ExEngine will automatically recognize and wrap objects from the Micro-Manager, OpenWFS and Harvesters backends.
+    In addition, it should be easy to write custom wrappers for other hardware.
+    Wrapping involves:
+    - exposing public properties and attributes in a thread-safe way (happens automatically)
+    - converting all method calls to scheduled tasks, returning ExecutionFutures (happens automatically)
+    - renaming methods and attributes to match the ExEngine schema (needs to be done manually)
+    - implementing methods and properties that are required in the ExEngine schema (needs to be done manually)
+    - adding metadata to the object for automatic validation, and for displaying the attribute in the gui.
+    """
+
+    # rename some existing methods and attributes to match the exengine schema
+    # remove some that are not needed
+    _exengine_name_map = {"axis1": "x", "axis2": "y", "bogus_attribute": None}
+
+    def _x_max(self):
+        return self.getAxisLimits(0)
+
+    def _y_max(self):
+        return self.getAxisLimits(1)
+
+    # add missing metadata, using functions for dynamic or device-dependent metadata
+    x: Annotated[float, Gt(0.0), Unit("mm"), Lt(_x_max)]
+    y: Annotated[float, Gt(0.0), Unit("mm"), Lt(_y_max)]
+
+
+def setup_hardware(engine):
+    """
+    Initialize back ends and hardware.
+
+    The three camera's and the stages all require different backends
+    ExEngine recognizes and translates Harvesters, OpenWFS and Micro-Manager objects·
+    For the stage, we defined a custom wrapper.
+
+    Note: ExEngine does not affect the initialization of the backends itself, allowing
+    the user to use the full functionality of the backend libraries.
+    """
+    h = harvesters.core.Harvester()
+    h.add_file('/Users/kznr/dev/genicam/bin/Maci64_x64/TLSimu.cti')
+    h.update()
+    camera1 = engine.register("camera1", h.create(0))
+
+    camera2 = engine.register("camera2", openwfs.mockdevices.NoiseCamera("camera2"))
+
+    mmc = pymmcore.CMMCore()
+    mmc.setDeviceAdapterSearchPaths(["C:/Program Files/Micro-Manager-2.0.x"])
+    mmc.loadSystemConfiguration("MMConfig_demo.cfg")
+    camera3 = engine.register("camera3", mmc.getDeviceObject("cam"))
+
+    stage = engine.register("xystage", SuperStageWrapper())
+    return (camera1, camera2, camera3), stage
+
+
+if __file__ == "__main__":
+    # Initialize ExEngine
+    engine = ExecutionEngine()
+
+    # Construct a graphical user interface
+    gui = exengine.gui.PyQT(engine)
+
+    # initialize hardware components
+    cameras, stage = setup_hardware(engine)
+
+    # register the custom class. The 'Calibrate' button is automatically added to the property browser for the object
+    stage = engine.register("calibration_script", CalibrationWidget(cameras, stage))
+
+    # Run the GUI
+    gui.run()
+
+    engine.shutdown() # should not be needed?
+
+

--- a/src/exengine/examples/complex_use_case.py
+++ b/src/exengine/examples/complex_use_case.py
@@ -40,10 +40,7 @@ class CalibrationWidget:
         will automatically provide a callback object that can be used to report progress.
         At every call to the 'update' method of this object, the progress bar in the GUI is updated.
         This also allows the user to cancel the operation, resulting in an asyncio.CancelledError exception.
-    * Inter-object synchronization. In the call to 'run', the Widget *and all its child devices* are locked
-        and form a synchronization group. By default, all actuators in a synchronization group (the stage)
-        wait for all sensors (the cameras) to complete before starting to execute a command. Vice versa,
-        all sensors wait for all actuators to complete before starting to acquire data.
+    * Inter-object synchronization using the 'after' parameter.
     * Asynchronous programming. The 'capture' method of the camera returns a future.
         Instead of storing the frames, the futures are stored in a list. In this case, all measurements may get
         scheduled before the first one is completed.
@@ -69,12 +66,12 @@ class CalibrationWidget:
     def run(self, engine, /, *, _progress):
         _progress.total = self.step_count * 2
         _progress.description = "Calibrating camera magnifications"
-        for axis in ["x", "y"]:
+        for axis in range(2):
             all_images = []
-            start = getattr(stage, axis)
+            start = stage.position[axis]
             for i in range(10):
-                setattr(stage, axis, start + i * self.step_size)
-                frames = [camera.capture() for camera in cameras]
+                move_stage = stage.move_to(axis=axis, position=start + i * self.step_size)
+                frames = [camera.capture(after=move_stage) for camera in cameras]
                 frames[-1].on_complete.append(lambda: _progress.update(1))
                 all_images.append(frames)
 

--- a/src/exengine/integration_tests/test_preferred_thread_annotations.py
+++ b/src/exengine/integration_tests/test_preferred_thread_annotations.py
@@ -21,11 +21,9 @@ class DecoratedEvent(ThreadRecordingEvent):
 
 class TestDevice(Device):
 
-    def __init__(self, name, engine):
-        super().__init__(engine=engine, name=name, no_executor_attrs=('_attribute', 'set_attribute_thread',
-                                                  'get_attribute_thread', 'regular_method_thread',
-                                                  'decorated_method_thread'))
+    def __init__(self, _name, _engine):
         self._attribute = 123
+        self.set_attribute_thread = "Not set"
 
     @property
     def attribute(self):
@@ -48,10 +46,7 @@ class TestDevice(Device):
 @on_thread("CustomDeviceThread")
 class CustomThreadTestDevice(Device):
 
-    def __init__(self, engine, name):
-        super().__init__(engine, name, no_executor_attrs=('_attribute',
-                                                  'set_attribute_thread', 'get_attribute_thread',
-                                                  'regular_method_thread', 'decorated_method_thread'))
+    def __init__(self, _name, _engine):
         self._attribute = 123
 
     @property
@@ -105,6 +100,7 @@ def test_device_attribute_access(engine):
     """
     device = TestDevice("TestDevice", engine)
     device.attribute = 'something'
+    read_back = device.attribute
     assert device.set_attribute_thread == _MAIN_THREAD_NAME
 
 def test_device_regular_method_access(engine):

--- a/src/exengine/integration_tests/test_preferred_thread_annotations.py
+++ b/src/exengine/integration_tests/test_preferred_thread_annotations.py
@@ -24,6 +24,8 @@ class TestDevice(Device):
     def __init__(self, _name, _engine):
         self._attribute = 123
         self.set_attribute_thread = "Not set"
+        self.regular_method_thread = "Not set"
+        self.decorated_method_thread = "Not set"
 
     @property
     def attribute(self):
@@ -48,6 +50,9 @@ class CustomThreadTestDevice(Device):
 
     def __init__(self, _name, _engine):
         self._attribute = 123
+        self.get_attribute_thread = "Not set"
+        self.set_attribute_thread = "Not set"
+        self.regular_method_thread = "Not set"
 
     @property
     def attribute(self):
@@ -123,7 +128,7 @@ def test_custom_thread_device_attribute_access(engine):
     """
     Test that device attribute access runs on the custom thread when specified.
     """
-    custom_device = CustomThreadTestDevice(engine, "CustomDevice")
+    custom_device = CustomThreadTestDevice( "CustomDevice", engine)
     custom_device.attribute = 'something'
     assert custom_device.set_attribute_thread == "CustomDeviceThread"
 
@@ -131,7 +136,7 @@ def test_custom_thread_device_property_access(engine):
     """
     Test that device property access runs on the custom thread when specified.
     """
-    custom_device = CustomThreadTestDevice(engine,"CustomDevice")
+    custom_device = CustomThreadTestDevice("CustomDevice", engine)
     custom_device.attribute = 'something'
     assert custom_device.set_attribute_thread == "CustomDeviceThread"
 
@@ -141,8 +146,7 @@ def test_custom_thread_device_property_access(engine):
 
 @on_thread("OuterThread")
 class OuterThreadDevice(Device):
-    def __init__(self, engine, name,  inner_device):
-        super().__init__(engine, name)
+    def __init__(self, _name, _engine,  inner_device):
         self.inner_device = inner_device
         self.outer_thread = None
 
@@ -153,8 +157,7 @@ class OuterThreadDevice(Device):
 
 @on_thread("InnerThread")
 class InnerThreadDevice(Device):
-    def __init__(self, engine, name):
-        super().__init__(engine, name)
+    def __init__(self, _name, _engine):
         self.inner_thread = None
 
     def inner_method(self):
@@ -166,8 +169,8 @@ def test_nested_thread_switch(engine):
     Test that nested calls to methods with different thread specifications
     result in correct thread switches at each level.
     """
-    inner_device = InnerThreadDevice(engine, "InnerDevice")
-    outer_device = OuterThreadDevice(engine, "OuterDevice", inner_device)
+    inner_device = InnerThreadDevice("InnerDevice", engine)
+    outer_device = OuterThreadDevice("OuterDevice", engine, inner_device)
 
     class OuterEvent(ExecutorEvent):
         def execute(self):
@@ -205,7 +208,7 @@ def test_multiple_decorators(engine):
     """
     Test that the thread decorator works correctly when combined with other decorators.
     """
-    device = MultiDecoratedDevice(engine, "MultiDevice")
+    device = MultiDecoratedDevice("MultiDevice", engine)
 
     class MultiEvent(ExecutorEvent):
         def execute(self):

--- a/src/exengine/kernel/data_handler.py
+++ b/src/exengine/kernel/data_handler.py
@@ -5,6 +5,7 @@ import numpy.typing as npt
 from pydantic.types import JsonValue
 from dataclasses import dataclass
 
+from .executor import ExecutionEngine
 from .notification_base import DataStoredNotification
 from .data_coords import DataCoordinates
 from .data_storage_base import DataStorage
@@ -49,17 +50,11 @@ class DataHandler:
     # This class must create at least one additional thread (the saving thread)
     # and may create another for processing data
 
-    def __init__(self, storage: DataStorage,
+    def __init__(self, engine: ExecutionEngine, storage: DataStorage,
                  process_function: Callable[[DataCoordinates, npt.NDArray["Any"], JsonValue],
                                 Optional[Union[DataCoordinates, npt.NDArray["Any"], JsonValue,
-                                               Tuple[DataCoordinates, npt.NDArray["Any"], JsonValue]]]] = None,
-                 _executor=None):
-        # delayed import to avoid circular imports
-        if _executor is None:
-            from .executor import ExecutionEngine
-            self._engine = ExecutionEngine.get_instance()
-        else:
-            self._engine = _executor
+                                               Tuple[DataCoordinates, npt.NDArray["Any"], JsonValue]]]] = None):
+        self._engine = engine
         self._storage = storage
         self._process_function = process_function
         self._intake_queue = _PeekableQueue()

--- a/src/exengine/kernel/device.py
+++ b/src/exengine/kernel/device.py
@@ -1,192 +1,146 @@
 """
 Base class for all device_implementations that integrates with the execution engine and enables tokenization of device access.
 """
-from abc import ABCMeta, ABC
 from functools import wraps
-from typing import Any, Sequence, Optional, Tuple, Iterable, Union
 from weakref import WeakSet
 
 import threading
 import sys
 
-from .executor import MethodCallEvent, GetAttrEvent, SetAttrEvent
+from .executor import MethodCallEvent, GetAttrEvent, SetAttrEvent, ExecutionEngine
+
+# class DeviceMetaclass(ABCMeta):
+#     """
+#     Metaclass for device_implementations that wraps all methods and attributes in the device class to add the ability to
+#     control their execution and access. This has two purposes:
+#
+#     1) Add the ability to record all method calls and attribute accesses for tokenization
+#     2) Add the ability to make all methods and attributes thread-safe by putting them on the Executor
+#     3) Automatically register all instances of the device with the ExecutionEngine
+#     """
+#     @staticmethod
+#     def wrap_for_executor(attr_name, attr_value):
+#         if hasattr(attr_value, '_wrapped_for_executor'):
+#             return attr_value
+#
+#         # Add this block to handle properties
+#         if isinstance(attr_value, property):
+#             return property(
+#                 fget=DeviceMetaclass.wrap_for_executor(f"{attr_name}_getter", attr_value.fget) if attr_value.fget else None,
+#                 fset=DeviceMetaclass.wrap_for_executor(f"{attr_name}_setter", attr_value.fset) if attr_value.fset else None,
+#                 fdel=DeviceMetaclass.wrap_for_executor(f"{attr_name}_deleter", attr_value.fdel) if attr_value.fdel else None,
+#                 doc=attr_value.__doc__
+#             )
+#
+#         @wraps(attr_value)
+#         def wrapper(self: 'Device', *args: Any, **kwargs: Any) -> Any:
+#             if attr_name in _no_executor_attrs or self._no_executor:
+#                 return attr_value(self, *args, **kwargs)
+#             if DeviceMetaclass._is_reroute_exempted_thread():
+#                 return attr_value(self, *args, **kwargs)
+#             # check for method-level preferred thread name first, then class-level
+#             thread_name = getattr(attr_value, '_thread_name', None) or getattr(self, '_thread_name', None)
+#             #if ExecutionEngine.on_any_executor_thread():
+#                 # check for device-level preferred thread
+#             #    if thread_name is None or threading.current_thread().name == thread_name:
+#             #        return attr_value(self, *args, **kwargs)
+#             event = MethodCallEvent(method_name=attr_name, args=args, kwargs=kwargs, instance=self)
+#             return self._engine.submit(event, thread_name=thread_name).await_execution()
+#
+#         wrapper._wrapped_for_executor = True
+#         return wrapper
+#
+#     @staticmethod
+#     def is_debugger_thread():
+#         if not _python_debugger_active:
+#             return False
+#         # This is a heuristic and may need adjustment based on the debugger used.
+#         debugger_thread_names = ["pydevd", "Debugger", "GetValueAsyncThreadDebug"]  # Common names for debugger threads
+#         current_thread = threading.current_thread()
+#         # Check if current thread name contains any known debugger thread names
+#         return any(name in current_thread.name or name in str(current_thread.__class__.__name__)
+#                    for name in debugger_thread_names)
+#
+#     @staticmethod
+#     def _is_reroute_exempted_thread() -> bool:
+#         return DeviceMetaclass.is_debugger_thread() or threading.current_thread() in _within_executor_threads
+#
+#     @staticmethod
+#     def find_in_bases(bases, method_name):
+#         for base in bases:
+#             if hasattr(base, method_name):
+#                 return getattr(base, method_name)
+#         return None
+#
+#     def __new__(mcs, name: str, bases: tuple, attrs: dict) -> Any:
+#         new_attrs = {}
+#         for attr_name, attr_value in attrs.items():
+#             if not attr_name.startswith('_'):
+#                 if isinstance(attr_value, property):  # Property
+#                     new_attrs[attr_name] = mcs.wrap_for_executor(attr_name, attr_value)
+#                 elif callable(attr_value):  # Regular method
+#                     new_attrs[attr_name] = mcs.wrap_for_executor(attr_name, attr_value)
+#                 else:  # Attribute
+#                     new_attrs[attr_name] = attr_value
+#             else:
+#                 new_attrs[attr_name] = attr_value
+#
+#
+#         original_setattr = attrs.get('__setattr__') or mcs.find_in_bases(bases, '__setattr__') or object.__setattr__
+#         def getattribute_with_fallback(self, name):
+#             """ Wrap the getattribute method to fallback to getattr if an attribute is not found """
+#             try:
+#                 return object.__getattribute__(self, name)
+#             except AttributeError:
+#                 try:
+#                     return self.__getattr__(name)
+#                 except AttributeError as e:
+#                     if _python_debugger_active and (name == 'shape' or name == '__len__'):
+#                         pass  # This prevents a bunch of irrelevant errors in the Pycharm debugger
+#                     else:
+#                         raise e
+#
+#         def __getattribute__(self: 'Device', name: str) -> Any:
+#             if name.startswith('_') or name in _no_executor_attrs or self._no_executor:
+#                 return object.__getattribute__(self, name)
+#             if DeviceMetaclass._is_reroute_exempted_thread():
+#                 return getattribute_with_fallback(self, name)
+#             thread_name = getattr(self, '_thread_name', None)
+#             #if ExecutionEngine.on_any_executor_thread():
+#             #    # check for device-level preferred thread
+#             #    if thread_name is None or threading.current_thread().name == thread_name:
+#             #        return getattribute_with_fallback(self, name)
+#             event = GetAttrEvent(attr_name=name, instance=self, method=getattribute_with_fallback)
+#             return self._engine.submit(event, thread_name=thread_name).await_execution()
+#
+#         def __setattr__(self: 'Device', name: str, value: Any) -> None:
+#             if name in _no_executor_attrs or self._no_executor:
+#                 return original_setattr(self, name, value)
+#             if DeviceMetaclass._is_reroute_exempted_thread():
+#                 return original_setattr(self, name, value)
+#             thread_name = getattr(self, '_thread_name', None)
+#             # if ExecutionEngine.on_any_executor_thread():
+#             #     # Check for device-level preferred thread
+#             #     if thread_name is None or threading.current_thread().name == thread_name:
+#             #         return original_setattr(self, name, value)
+#             event = SetAttrEvent(attr_name=name, value=value, instance=self, method=original_setattr)
+#             self._engine.submit(event, thread_name=thread_name).await_execution()
+#
+#         new_attrs['__getattribute__'] = __getattribute__
+#         new_attrs['__setattr__'] = __setattr__
+#
+#         new_attrs['_no_executor'] = True # For startup
+#         new_attrs['_no_executor_attrs'] = _no_executor_attrs
+#
+#
+#
+#         # Create the class
+#         cls = super().__new__(mcs, name, bases, new_attrs)
+#
+#         return cls
 
 
-def _initialize_thread_patching():
-    _python_debugger_active = any('pydevd' in sys.modules for frame in sys._current_frames().values())
-
-    # All threads that were created by code running on an executor thread, or created by threads that were created by
-    # code running on an executor thread etc. Don't want to auto-reroute these to the executor because this might have
-    # unintended consequences. So they need to be tracked and not rerouted
-    _within_executor_threads = WeakSet()
-
-    # Keep this list accessible outside of class attributes to avoid infinite recursion
-    # Note: This is already defined at module level, so we don't redefine it here
-
-    # def thread_start_hook(thread):
-    #     # keep track of threads that were created by code running on an executor thread so calls on them
-    #     # dont get rerouted to the executor
-    #     if ExecutionEngine.get_instance() and (
-    #             ExecutionEngine.on_any_executor_thread() or threading.current_thread() in _within_executor_threads):
-    #         _within_executor_threads.add(thread)
-    #
-    # # Monkey patch the threading module so we can monitor the creation of new threads
-    # _original_thread_start = threading.Thread.start
-    #
-    # # Define a new start method that adds the hook
-    # def _thread_start(self, *args, **kwargs):
-    #     try:
-    #         thread_start_hook(self)
-    #         _original_thread_start(self, *args, **kwargs)
-    #     except Exception as e:
-    #         print(f"Error in thread start hook: {e}")
-    #         # traceback.print_exc()
-    #
-    # # Replace the original start method with the new one
-    # threading.Thread.start = _thread_start
-    # threading.Thread._monkey_patched_start = True
-
-    return _python_debugger_active, _within_executor_threads
-
-
-# Call this function to initialize the thread patching
-if not hasattr(threading.Thread, '_monkey_patched_start'):
-    _python_debugger_active, _within_executor_threads = _initialize_thread_patching()
-    _no_executor_attrs = ['_name', '_no_executor', '_no_executor_attrs', '_thread_name']
-
-
-class DeviceMetaclass(ABCMeta):
-    """
-    Metaclass for device_implementations that wraps all methods and attributes in the device class to add the ability to
-    control their execution and access. This has two purposes:
-
-    1) Add the ability to record all method calls and attribute accesses for tokenization
-    2) Add the ability to make all methods and attributes thread-safe by putting them on the Executor
-    3) Automatically register all instances of the device with the ExecutionEngine
-    """
-    @staticmethod
-    def wrap_for_executor(attr_name, attr_value):
-        if hasattr(attr_value, '_wrapped_for_executor'):
-            return attr_value
-
-        # Add this block to handle properties
-        if isinstance(attr_value, property):
-            return property(
-                fget=DeviceMetaclass.wrap_for_executor(f"{attr_name}_getter", attr_value.fget) if attr_value.fget else None,
-                fset=DeviceMetaclass.wrap_for_executor(f"{attr_name}_setter", attr_value.fset) if attr_value.fset else None,
-                fdel=DeviceMetaclass.wrap_for_executor(f"{attr_name}_deleter", attr_value.fdel) if attr_value.fdel else None,
-                doc=attr_value.__doc__
-            )
-
-        @wraps(attr_value)
-        def wrapper(self: 'Device', *args: Any, **kwargs: Any) -> Any:
-            if attr_name in _no_executor_attrs or self._no_executor:
-                return attr_value(self, *args, **kwargs)
-            if DeviceMetaclass._is_reroute_exempted_thread():
-                return attr_value(self, *args, **kwargs)
-            # check for method-level preferred thread name first, then class-level
-            thread_name = getattr(attr_value, '_thread_name', None) or getattr(self, '_thread_name', None)
-            #if ExecutionEngine.on_any_executor_thread():
-                # check for device-level preferred thread
-            #    if thread_name is None or threading.current_thread().name == thread_name:
-            #        return attr_value(self, *args, **kwargs)
-            event = MethodCallEvent(method_name=attr_name, args=args, kwargs=kwargs, instance=self)
-            return self._engine.submit(event, thread_name=thread_name).await_execution()
-
-        wrapper._wrapped_for_executor = True
-        return wrapper
-
-    @staticmethod
-    def is_debugger_thread():
-        if not _python_debugger_active:
-            return False
-        # This is a heuristic and may need adjustment based on the debugger used.
-        debugger_thread_names = ["pydevd", "Debugger", "GetValueAsyncThreadDebug"]  # Common names for debugger threads
-        current_thread = threading.current_thread()
-        # Check if current thread name contains any known debugger thread names
-        return any(name in current_thread.name or name in str(current_thread.__class__.__name__)
-                   for name in debugger_thread_names)
-
-    @staticmethod
-    def _is_reroute_exempted_thread() -> bool:
-        return DeviceMetaclass.is_debugger_thread() or threading.current_thread() in _within_executor_threads
-
-    @staticmethod
-    def find_in_bases(bases, method_name):
-        for base in bases:
-            if hasattr(base, method_name):
-                return getattr(base, method_name)
-        return None
-
-    def __new__(mcs, name: str, bases: tuple, attrs: dict) -> Any:
-        new_attrs = {}
-        for attr_name, attr_value in attrs.items():
-            if not attr_name.startswith('_'):
-                if isinstance(attr_value, property):  # Property
-                    new_attrs[attr_name] = mcs.wrap_for_executor(attr_name, attr_value)
-                elif callable(attr_value):  # Regular method
-                    new_attrs[attr_name] = mcs.wrap_for_executor(attr_name, attr_value)
-                else:  # Attribute
-                    new_attrs[attr_name] = attr_value
-            else:
-                new_attrs[attr_name] = attr_value
-
-
-        original_setattr = attrs.get('__setattr__') or mcs.find_in_bases(bases, '__setattr__') or object.__setattr__
-        def getattribute_with_fallback(self, name):
-            """ Wrap the getattribute method to fallback to getattr if an attribute is not found """
-            try:
-                return object.__getattribute__(self, name)
-            except AttributeError:
-                try:
-                    return self.__getattr__(name)
-                except AttributeError as e:
-                    if _python_debugger_active and (name == 'shape' or name == '__len__'):
-                        pass  # This prevents a bunch of irrelevant errors in the Pycharm debugger
-                    else:
-                        raise e
-
-        def __getattribute__(self: 'Device', name: str) -> Any:
-            if name.startswith('_') or name in _no_executor_attrs or self._no_executor:
-                return object.__getattribute__(self, name)
-            if DeviceMetaclass._is_reroute_exempted_thread():
-                return getattribute_with_fallback(self, name)
-            thread_name = getattr(self, '_thread_name', None)
-            #if ExecutionEngine.on_any_executor_thread():
-            #    # check for device-level preferred thread
-            #    if thread_name is None or threading.current_thread().name == thread_name:
-            #        return getattribute_with_fallback(self, name)
-            event = GetAttrEvent(attr_name=name, instance=self, method=getattribute_with_fallback)
-            return self._engine.submit(event, thread_name=thread_name).await_execution()
-
-        def __setattr__(self: 'Device', name: str, value: Any) -> None:
-            if name in _no_executor_attrs or self._no_executor:
-                return original_setattr(self, name, value)
-            if DeviceMetaclass._is_reroute_exempted_thread():
-                return original_setattr(self, name, value)
-            thread_name = getattr(self, '_thread_name', None)
-            # if ExecutionEngine.on_any_executor_thread():
-            #     # Check for device-level preferred thread
-            #     if thread_name is None or threading.current_thread().name == thread_name:
-            #         return original_setattr(self, name, value)
-            event = SetAttrEvent(attr_name=name, value=value, instance=self, method=original_setattr)
-            self._engine.submit(event, thread_name=thread_name).await_execution()
-
-        new_attrs['__getattribute__'] = __getattribute__
-        new_attrs['__setattr__'] = __setattr__
-
-        new_attrs['_no_executor'] = True # For startup
-        new_attrs['_no_executor_attrs'] = _no_executor_attrs
-
-
-
-        # Create the class
-        cls = super().__new__(mcs, name, bases, new_attrs)
-
-        return cls
-
-
-class Device(ABC, metaclass=DeviceMetaclass):
+class Device:
     """
     Required base class for all devices usable with the execution engine
 
@@ -200,44 +154,48 @@ class Device(ABC, metaclass=DeviceMetaclass):
     Device implementations can also implement functionality through properties (i.e. attributes that are actually
     methods) by defining a getter and setter method for the property.
     """
+    def __new__(cls, name: str, engine: "ExecutionEngine", *args, **kwargs):
+        obj = super().__new__(cls)
+        obj.__init__(name, engine, *args, **kwargs)
+        return engine.register(name, obj)
 
-    def __init__(self, engine: "ExecutionEngine", name: str, no_executor: bool = False, no_executor_attrs: Sequence[str] = ('_name', )):
-        """
-        Create a new device
-
-        :param name: The name of the device
-        :param no_executor: If True, all methods and attributes will be executed directly on the calling thread instead
-        of being rerouted to the executor
-        :param no_executor_attrs: If no_executor is False, this is a list of attribute names that will be executed
-        directly on the calling thread
-        """
-        self._engine = engine
-        self._no_executor_attrs.extend(no_executor_attrs)
-        self._no_executor = no_executor
-        self._name = name
-        engine.register_device(name, self)
-
-
-    def get_allowed_property_values(self, property_name: str) -> Optional[list[str]]:
-        return None  # By default, any value is allowed
-
-    def is_property_read_only(self, property_name: str) -> bool:
-        return False  # By default, properties are writable
-
-    def get_property_limits(self, property_name: str) -> Tuple[Optional[float], Optional[float]]:
-        return (None, None)  # By default, no limits
-
-    def is_property_hardware_triggerable(self, property_name: str) -> bool:
-        return False  # By default, properties are not hardware triggerable
-
-    def get_triggerable_sequence_max_length(self, property_name: str) -> int:
-        raise NotImplementedError(f"get_triggerable_sequence_max_length is not implemented for {property_name}")
-
-    def load_triggerable_sequence(self, property_name: str, event_sequence: Iterable[Union[str, float, int]]):
-        raise NotImplementedError(f"load_triggerable_sequence is not implemented for {property_name}")
-
-    def start_triggerable_sequence(self, property_name: str):
-        raise NotImplementedError(f"start_triggerable_sequence is not implemented for {property_name}")
-
-    def stop_triggerable_sequence(self, property_name: str):
-        raise NotImplementedError(f"stop_triggerable_sequence is not implemented for {property_name}")
+    # def __init__(self, engine: "ExecutionEngine", name: str, no_executor: bool = False, no_executor_attrs: Sequence[str] = ('_name', )):
+    #     """
+    #     Create a new device
+    #
+    #     :param name: The name of the device
+    #     :param no_executor: If True, all methods and attributes will be executed directly on the calling thread instead
+    #     of being rerouted to the executor
+    #     :param no_executor_attrs: If no_executor is False, this is a list of attribute names that will be executed
+    #     directly on the calling thread
+    #     """
+    #     self._engine = engine
+    #     self._no_executor_attrs.extend(no_executor_attrs)
+    #     self._no_executor = no_executor
+    #     self._name = name
+    #     engine.register_device(name, self)
+    #
+    #
+    # def get_allowed_property_values(self, property_name: str) -> Optional[list[str]]:
+    #     return None  # By default, any value is allowed
+    #
+    # def is_property_read_only(self, property_name: str) -> bool:
+    #     return False  # By default, properties are writable
+    #
+    # def get_property_limits(self, property_name: str) -> Tuple[Optional[float], Optional[float]]:
+    #     return (None, None)  # By default, no limits
+    #
+    # def is_property_hardware_triggerable(self, property_name: str) -> bool:
+    #     return False  # By default, properties are not hardware triggerable
+    #
+    # def get_triggerable_sequence_max_length(self, property_name: str) -> int:
+    #     raise NotImplementedError(f"get_triggerable_sequence_max_length is not implemented for {property_name}")
+    #
+    # def load_triggerable_sequence(self, property_name: str, event_sequence: Iterable[Union[str, float, int]]):
+    #     raise NotImplementedError(f"load_triggerable_sequence is not implemented for {property_name}")
+    #
+    # def start_triggerable_sequence(self, property_name: str):
+    #     raise NotImplementedError(f"start_triggerable_sequence is not implemented for {property_name}")
+    #
+    # def stop_triggerable_sequence(self, property_name: str):
+    #     raise NotImplementedError(f"stop_triggerable_sequence is not implemented for {property_name}")

--- a/src/exengine/kernel/device.py
+++ b/src/exengine/kernel/device.py
@@ -1,55 +1,5 @@
-"""
-Base class for all device_implementations that integrates with the execution engine and enables tokenization of device access.
-"""
-from functools import wraps
-from weakref import WeakSet
+from .executor import ExecutionEngine
 
-import threading
-import sys
-
-from .executor import MethodCallEvent, GetAttrEvent, SetAttrEvent, ExecutionEngine
-
-# class DeviceMetaclass(ABCMeta):
-#     """
-#     Metaclass for device_implementations that wraps all methods and attributes in the device class to add the ability to
-#     control their execution and access. This has two purposes:
-#
-#     1) Add the ability to record all method calls and attribute accesses for tokenization
-#     2) Add the ability to make all methods and attributes thread-safe by putting them on the Executor
-#     3) Automatically register all instances of the device with the ExecutionEngine
-#     """
-#     @staticmethod
-#     def wrap_for_executor(attr_name, attr_value):
-#         if hasattr(attr_value, '_wrapped_for_executor'):
-#             return attr_value
-#
-#         # Add this block to handle properties
-#         if isinstance(attr_value, property):
-#             return property(
-#                 fget=DeviceMetaclass.wrap_for_executor(f"{attr_name}_getter", attr_value.fget) if attr_value.fget else None,
-#                 fset=DeviceMetaclass.wrap_for_executor(f"{attr_name}_setter", attr_value.fset) if attr_value.fset else None,
-#                 fdel=DeviceMetaclass.wrap_for_executor(f"{attr_name}_deleter", attr_value.fdel) if attr_value.fdel else None,
-#                 doc=attr_value.__doc__
-#             )
-#
-#         @wraps(attr_value)
-#         def wrapper(self: 'Device', *args: Any, **kwargs: Any) -> Any:
-#             if attr_name in _no_executor_attrs or self._no_executor:
-#                 return attr_value(self, *args, **kwargs)
-#             if DeviceMetaclass._is_reroute_exempted_thread():
-#                 return attr_value(self, *args, **kwargs)
-#             # check for method-level preferred thread name first, then class-level
-#             thread_name = getattr(attr_value, '_thread_name', None) or getattr(self, '_thread_name', None)
-#             #if ExecutionEngine.on_any_executor_thread():
-#                 # check for device-level preferred thread
-#             #    if thread_name is None or threading.current_thread().name == thread_name:
-#             #        return attr_value(self, *args, **kwargs)
-#             event = MethodCallEvent(method_name=attr_name, args=args, kwargs=kwargs, instance=self)
-#             return self._engine.submit(event, thread_name=thread_name).await_execution()
-#
-#         wrapper._wrapped_for_executor = True
-#         return wrapper
-#
 #     @staticmethod
 #     def is_debugger_thread():
 #         if not _python_debugger_active:
@@ -61,121 +11,31 @@ from .executor import MethodCallEvent, GetAttrEvent, SetAttrEvent, ExecutionEngi
 #         return any(name in current_thread.name or name in str(current_thread.__class__.__name__)
 #                    for name in debugger_thread_names)
 #
-#     @staticmethod
-#     def _is_reroute_exempted_thread() -> bool:
-#         return DeviceMetaclass.is_debugger_thread() or threading.current_thread() in _within_executor_threads
-#
-#     @staticmethod
-#     def find_in_bases(bases, method_name):
-#         for base in bases:
-#             if hasattr(base, method_name):
-#                 return getattr(base, method_name)
-#         return None
-#
-#     def __new__(mcs, name: str, bases: tuple, attrs: dict) -> Any:
-#         new_attrs = {}
-#         for attr_name, attr_value in attrs.items():
-#             if not attr_name.startswith('_'):
-#                 if isinstance(attr_value, property):  # Property
-#                     new_attrs[attr_name] = mcs.wrap_for_executor(attr_name, attr_value)
-#                 elif callable(attr_value):  # Regular method
-#                     new_attrs[attr_name] = mcs.wrap_for_executor(attr_name, attr_value)
-#                 else:  # Attribute
-#                     new_attrs[attr_name] = attr_value
-#             else:
-#                 new_attrs[attr_name] = attr_value
-#
-#
-#         original_setattr = attrs.get('__setattr__') or mcs.find_in_bases(bases, '__setattr__') or object.__setattr__
-#         def getattribute_with_fallback(self, name):
-#             """ Wrap the getattribute method to fallback to getattr if an attribute is not found """
-#             try:
-#                 return object.__getattribute__(self, name)
-#             except AttributeError:
-#                 try:
-#                     return self.__getattr__(name)
-#                 except AttributeError as e:
-#                     if _python_debugger_active and (name == 'shape' or name == '__len__'):
-#                         pass  # This prevents a bunch of irrelevant errors in the Pycharm debugger
-#                     else:
-#                         raise e
-#
-#         def __getattribute__(self: 'Device', name: str) -> Any:
-#             if name.startswith('_') or name in _no_executor_attrs or self._no_executor:
-#                 return object.__getattribute__(self, name)
-#             if DeviceMetaclass._is_reroute_exempted_thread():
-#                 return getattribute_with_fallback(self, name)
-#             thread_name = getattr(self, '_thread_name', None)
-#             #if ExecutionEngine.on_any_executor_thread():
-#             #    # check for device-level preferred thread
-#             #    if thread_name is None or threading.current_thread().name == thread_name:
-#             #        return getattribute_with_fallback(self, name)
-#             event = GetAttrEvent(attr_name=name, instance=self, method=getattribute_with_fallback)
-#             return self._engine.submit(event, thread_name=thread_name).await_execution()
-#
-#         def __setattr__(self: 'Device', name: str, value: Any) -> None:
-#             if name in _no_executor_attrs or self._no_executor:
-#                 return original_setattr(self, name, value)
-#             if DeviceMetaclass._is_reroute_exempted_thread():
-#                 return original_setattr(self, name, value)
-#             thread_name = getattr(self, '_thread_name', None)
-#             # if ExecutionEngine.on_any_executor_thread():
-#             #     # Check for device-level preferred thread
-#             #     if thread_name is None or threading.current_thread().name == thread_name:
-#             #         return original_setattr(self, name, value)
-#             event = SetAttrEvent(attr_name=name, value=value, instance=self, method=original_setattr)
-#             self._engine.submit(event, thread_name=thread_name).await_execution()
-#
-#         new_attrs['__getattribute__'] = __getattribute__
-#         new_attrs['__setattr__'] = __setattr__
-#
-#         new_attrs['_no_executor'] = True # For startup
-#         new_attrs['_no_executor_attrs'] = _no_executor_attrs
-#
-#
-#
-#         # Create the class
-#         cls = super().__new__(mcs, name, bases, new_attrs)
-#
-#         return cls
-
 
 class Device:
     """
-    Required base class for all devices usable with the execution engine
+    Base class that causes the object to be automatically registered on creation.
 
-    Device classes should inherit from this class and implement the abstract methods. The DeviceMetaclass will wrap all
-    methods and attributes in the class to make them thread-safe and to optionally record all method calls and
-    attribute accesses.
+    Usage:
+        class MyDevice(Device):
+            def __init__(self, name: str, engine: ExecutionEngine, ...):
+                ...
 
-    Attributes with a trailing _noexec will not be wrapped and will be executed directly on the calling thread. This is
-    useful for attributes that are not hardware related and can bypass the complexity of the executor.
+        engine = ExecutionEngine()
+        device = MyDevice("device_name", engine, ...)
 
-    Device implementations can also implement functionality through properties (i.e. attributes that are actually
-    methods) by defining a getter and setter method for the property.
+    Has the same effect as:
+        class MyDevice:
+            ...
+
+        engine = ExecutionEngine()
+        device = engine.register("device_name", MyDevice(...))
     """
     def __new__(cls, name: str, engine: "ExecutionEngine", *args, **kwargs):
         obj = super().__new__(cls)
         obj.__init__(name, engine, *args, **kwargs)
         return engine.register(name, obj)
 
-    # def __init__(self, engine: "ExecutionEngine", name: str, no_executor: bool = False, no_executor_attrs: Sequence[str] = ('_name', )):
-    #     """
-    #     Create a new device
-    #
-    #     :param name: The name of the device
-    #     :param no_executor: If True, all methods and attributes will be executed directly on the calling thread instead
-    #     of being rerouted to the executor
-    #     :param no_executor_attrs: If no_executor is False, this is a list of attribute names that will be executed
-    #     directly on the calling thread
-    #     """
-    #     self._engine = engine
-    #     self._no_executor_attrs.extend(no_executor_attrs)
-    #     self._no_executor = no_executor
-    #     self._name = name
-    #     engine.register_device(name, self)
-    #
-    #
     # def get_allowed_property_values(self, property_name: str) -> Optional[list[str]]:
     #     return None  # By default, any value is allowed
     #

--- a/src/exengine/kernel/ex_event_base.py
+++ b/src/exengine/kernel/ex_event_base.py
@@ -134,15 +134,14 @@ class AnonymousCallableEvent(ExecutorEvent):
     The callable object should take no arguments and optionally return a value.
     """
     def __init__(self, callable_obj: Callable[[], Any]):
-        super().__init__()
-        self.callable_obj = callable_obj
         # Check if the callable has no parameters (except for 'self' in case of methods)
         if not callable(callable_obj):
             raise TypeError("Callable object must be a function or method")
-        signature = inspect.signature(callable_obj)
-        if not all(param.default != param.empty or param.kind == param.VAR_POSITIONAL for param in
-               signature.parameters.values()):
+        if not inspect.signature(callable_obj).bind():
             raise TypeError("Callable object must take no arguments")
+
+        super().__init__()
+        self.callable_obj = callable_obj
 
 
     def execute(self):

--- a/src/exengine/kernel/ex_event_base.py
+++ b/src/exengine/kernel/ex_event_base.py
@@ -46,10 +46,15 @@ class ExecutorEvent(ABC, metaclass=_ExecutorEventMeta):
     def __init__(self, *args, **kwargs):
         super().__init__()
         self._num_retries_on_exception = 0
+        self._priority = 1 # lower number means higher priority
         self._finished = False
         self._initialized = False
         # Check for method-level preferred thread name first, then class-level
         self._thread_name = getattr(self.execute, '_thread_name', None) or getattr(self.__class__, '_thread_name', None)
+
+    def __lt__(self, other: "ExecutorEvent") -> bool:
+        """Implement the < operator to allow sorting events by priority"""
+        return self._priority < other._priority
 
     def _pre_execution(self, engine) -> ExecutionFuture:
         """
@@ -95,17 +100,22 @@ class ExecutorEvent(ABC, metaclass=_ExecutorEventMeta):
         Method that is called after the event is executed to update acquisition futures about the event's status.
         This is called automatically by the Executor and should not be overriden by subclasses.
 
+        This method signals that the future is complete, so that any thread waiting on it can proceed.
+
         Args:
             return_value: Return value of the event
             exception: Exception that was raised during execution, if any
         """
         if self._future_weakref is None:
             raise Exception("Future not set for event")
-        future = self._future_weakref()
         self.finished = True
-        self._engine.publish_notification(EventExecutedNotification(payload=exception))
-        if future is not None:
-            future._notify_execution_complete(return_value, exception)
+        try:
+            self._engine.publish_notification(EventExecutedNotification(payload=exception))
+        finally:
+            future = self._future_weakref()
+            if future is not None:
+                print(f"Event {self} finished, notifying future")
+                future._notify_execution_complete(return_value, exception)
 
 
 

--- a/src/exengine/kernel/ex_event_base.py
+++ b/src/exengine/kernel/ex_event_base.py
@@ -58,6 +58,12 @@ class ExecutorEvent(ABC, metaclass=_ExecutorEventMeta):
             return True # always put 'None' at the end of the queue
         return self._priority < other._priority
 
+    def __gt__(self, other) -> bool:
+        """Implement the > operator to allow sorting events by priority"""
+        if other is None:
+            return False
+        return self._priority > other._priority
+
     def _pre_execution(self, engine) -> ExecutionFuture:
         """
         This is called automatically by the Executor and should not be overriden by subclasses.

--- a/src/exengine/kernel/ex_event_base.py
+++ b/src/exengine/kernel/ex_event_base.py
@@ -52,8 +52,10 @@ class ExecutorEvent(ABC, metaclass=_ExecutorEventMeta):
         # Check for method-level preferred thread name first, then class-level
         self._thread_name = getattr(self.execute, '_thread_name', None) or getattr(self.__class__, '_thread_name', None)
 
-    def __lt__(self, other: "ExecutorEvent") -> bool:
+    def __lt__(self, other) -> bool:
         """Implement the < operator to allow sorting events by priority"""
+        if other is None:
+            return True # always put 'None' at the end of the queue
         return self._priority < other._priority
 
     def _pre_execution(self, engine) -> ExecutionFuture:

--- a/src/exengine/kernel/executor.py
+++ b/src/exengine/kernel/executor.py
@@ -14,9 +14,7 @@ from .ex_event_base import ExecutorEvent, AnonymousCallableEvent
 from .ex_future import ExecutionFuture
 from .queue import PriorityQueue, Queue, Shutdown
 
-# todo: Remove singleton pattern. Remove related locking, __new__ override and other complications
 # todo: Add shutdown to __del__
-# todo: use [] operator for getting devices by id
 # todo: simplify worker threads:
 #   - remove enqueing on free thread -> replace by a thread pool mechanism
 #   - decouple enqueing and dequeing (related)
@@ -119,7 +117,7 @@ class ExecutionEngine:
         WrappedObject = type('_' + obj.__class__.__name__, (DeviceBase,), class_dict)
         # todo: cache dynamically generated classes
         wrapped = WrappedObject(self,obj)
-        self.register_device(id, wrapped)
+        self._devices[id] = wrapped
         return wrapped
 
     def subscribe_to_notifications(self, subscriber: Callable[[Notification], None],
@@ -199,18 +197,6 @@ class ExecutionEngine:
             KeyError if a device with this id is not found.
         """
         return self._devices[device_id]
-
-    def register_device(self, name: str, device):
-        """
-        Called automatically when a Device is created so that the ExecutionEngine can keep track of all devices
-        and look them up by their string names
-        """
-        # Make sure there's not already a device with this name
-        if name in self._devices:
-            raise ValueError(f"Device with name {name} already exists")
-        # todo: check if device is wrapped
-        self._devices[name] = device
-
 
     @staticmethod
     def on_any_executor_thread():

--- a/src/exengine/kernel/executor.py
+++ b/src/exengine/kernel/executor.py
@@ -13,6 +13,14 @@ from .ex_event_base import ExecutorEvent, AnonymousCallableEvent
 from .ex_future import ExecutionFuture
 from .queue import PriorityQueue, Queue, Shutdown
 
+# todo: Remove singleton pattern. Remove related locking, __new__ override and other complications
+# todo: Add shutdown to __del__
+# todo: use [] operator for getting devices by id
+# todo: simplify worker threads:
+#   - remove enqueing on free thread -> replace by a thread pool mechanism
+#   - decouple enqueing and dequeing (related)
+#   - remove is_free and related overhead
+# todo: simplify ExecutorEvent class and lifecycle
 
 _MAIN_THREAD_NAME = 'MainExecutorThread'
 _ANONYMOUS_THREAD_NAME = 'AnonymousExecutorThread'

--- a/src/exengine/kernel/executor.py
+++ b/src/exengine/kernel/executor.py
@@ -70,6 +70,13 @@ class DeviceBase:
 
         self._executor.shutdown(immediately, wait, AnonymousCallableEvent(do_shutdown))
 
+    @staticmethod
+    def map_names(class_dict):
+        """
+        Maps the names of the class to the device
+        """
+        pass
+
 class ExecutionEngine:
     _debug = False
 
@@ -86,7 +93,7 @@ class ExecutionEngine:
         self._notification_thread = None
 
 
-    def register(self, id: str, obj: object):
+    def register(self, id: str, obj: object, schema = DeviceBase):
         """
         Wraps an object for use with the ExecutionEngine
 
@@ -148,7 +155,8 @@ class ExecutionEngine:
                     slots.append(name)
 
         class_dict['__slots__'] = () # prevent addition of new attributes.
-        WrappedObject = type('_' + obj.__class__.__name__, (DeviceBase,), class_dict)
+        schema.map_names(class_dict)
+        WrappedObject = type('_' + obj.__class__.__name__, (schema,), class_dict)
         # todo: cache dynamically generated classes
         wrapped = WrappedObject(self,obj)
         self._devices[id] = wrapped

--- a/src/exengine/kernel/queue.py
+++ b/src/exengine/kernel/queue.py
@@ -1,9 +1,6 @@
 import queue
 import threading
 import warnings
-from typing import Generic, TypeVar
-
-from exengine.kernel.ex_event_base import ExecutorEvent
 
 # Abortable queue object used by the engine
 # For Python 3.13, such an object is provided by the standard library

--- a/src/exengine/kernel/queue.py
+++ b/src/exengine/kernel/queue.py
@@ -1,0 +1,64 @@
+import queue
+import threading
+import warnings
+from typing import Generic, TypeVar
+
+from exengine.kernel.ex_event_base import ExecutorEvent
+
+# Abortable queue object used by the engine
+# For Python 3.13, such an object is provided by the standard library
+# For older versions, we provide a compatible implementation
+
+if hasattr(queue, 'Shutdown'):
+    PriorityQueue = queue.PriorityQueue
+    Queue = queue.Queue
+    Shutdown = queue.Shutdown
+else:
+    # Pre-Python 3.13 compatibility
+    Shutdown = type('Shutdown', (BaseException,), {})
+    class ShutdownMixin:
+        def __init__(self):
+            super().__init__()
+            self._shutdown = threading.Event()
+
+        def shutdown(self, immediately=False):
+            """Shuts down the queue 'immediately' or after the current items are processed
+            Does not wait for the shutdown to complete (see join).
+            Note: this inserts 'None' sentinel values in the queue to signal termination.
+            """
+            already_shut_down = self._shutdown.is_set()
+            if already_shut_down:
+                warnings.warn("Queue already shut down", RuntimeWarning)
+
+            self._shutdown.set()
+            if immediately:
+                # Clear the queue
+                try:
+                    while self.get(block=False):
+                        self.task_done()
+                except queue.Empty:
+                    pass
+
+            if not already_shut_down:
+                super().put(None) # activate the worker thread if it is waiting at 'get'
+                self.task_done() # don't count None as actual task, don't wait for it in 'join'
+
+        def get(self, block=True, timeout=None):
+            retval = super().get(block, timeout)
+            if retval is None:
+                super().put(None)  # activate the next worker thread if it is waiting at 'get'
+                self.task_done()  # don't count None as actual task, don't wait for it in 'join'
+                raise Shutdown
+            else:
+                return retval
+
+        def put(self, item, block=True, timeout=None):
+            if self._shutdown.is_set():
+                raise Shutdown # thread is being shut down, cannot add more items
+            return super().put(item, block, timeout)
+
+    class PriorityQueue(ShutdownMixin, queue.PriorityQueue):
+        pass
+
+    class Queue(ShutdownMixin, queue.Queue):
+        pass

--- a/src/exengine/kernel/test/test_data_handler.py
+++ b/src/exengine/kernel/test/test_data_handler.py
@@ -44,7 +44,6 @@ class MockDataStorage(DataStorage):
 @pytest.fixture
 def mock_execution_engine(monkeypatch):
     mock_engine = Mock(spec=ExecutionEngine)
-    monkeypatch.setattr(ExecutionEngine, 'get_instance', lambda: mock_engine)
     return mock_engine
 
 @pytest.fixture
@@ -54,7 +53,7 @@ def mock_data_storage():
 
 @pytest.fixture
 def data_handler(mock_data_storage, mock_execution_engine):
-    dh = DataHandler(mock_data_storage, _executor=mock_execution_engine)
+    dh = DataHandler(mock_execution_engine, mock_data_storage)
     yield dh
     dh.finish()
 
@@ -80,10 +79,11 @@ def test_data_handler_processing_function(mock_data_storage):
     Test that DataHandler can process data using a provided processing function, and that
     data_handler.get() returns the processed data not the original data.
     """
+    engine = ExecutionEngine()
     def process_function(coords, image, metadata):
         return coords, image * 2, metadata
 
-    handler_with_processing = DataHandler(mock_data_storage, process_function)
+    handler_with_processing = DataHandler(engine, mock_data_storage, process_function)
 
     coords = DataCoordinates({"time": 1, "channel": "DAPI", "z": 0})
     image = np.array([[1, 2], [3, 4]], dtype=np.uint16)

--- a/src/exengine/kernel/test/test_device.py
+++ b/src/exengine/kernel/test/test_device.py
@@ -1,5 +1,7 @@
 import pytest
 from unittest.mock import MagicMock
+
+from exengine import ExecutionEngine
 from exengine.kernel.device import Device
 
 
@@ -58,7 +60,9 @@ def test_stop_triggerable_sequence(mock_device):
 class TestDeviceDefaults:
     @pytest.fixture
     def default_device(self):
-        return Device('default_device', no_executor=True)
+        engine = ExecutionEngine()
+        yield Device(engine=engine, name='default_device')
+        engine.shutdown()
 
     def test_get_allowed_property_values_default(self, default_device):
         assert default_device.get_allowed_property_values('test_property') is None

--- a/src/exengine/kernel/test/test_device.py
+++ b/src/exengine/kernel/test/test_device.py
@@ -57,6 +57,7 @@ def test_stop_triggerable_sequence(mock_device):
     mock_device.stop_triggerable_sequence('test_property')
     mock_device.stop_triggerable_sequence.assert_called_once_with('test_property')
 
+@pytest.mark.skip("Not implemented, needs to change to more systematic metadata storage")
 class TestDeviceDefaults:
     @pytest.fixture
     def default_device(self):

--- a/src/exengine/kernel/test/test_executor.py
+++ b/src/exengine/kernel/test/test_executor.py
@@ -257,6 +257,7 @@ def test_submit_multiple_events(engine):
     assert event2.executed
 
 
+@pytest.mark.skip("This test is broken. Even though event3 gets priority, it may execute after event2.")
 def test_event_prioritization(engine):
     """
     Test event prioritization in the ExecutionEngine.
@@ -278,6 +279,7 @@ def test_event_prioritization(engine):
     start_event1.wait()  # Wait for the first event to start executing
 
     engine.submit(event2)
+    # race condition, at this point the engine may or may not have started executing event2
     engine.submit(event3, prioritize=True)
 
     finish_event1.set()

--- a/src/exengine/kernel/test/test_executor.py
+++ b/src/exengine/kernel/test/test_executor.py
@@ -12,93 +12,62 @@ import time
 
 
 @pytest.fixture()
-def execution_engine():
-    engine = ExecutionEngine()
-    yield engine
-    engine.shutdown()
+def engine():
+    e = ExecutionEngine()
+    yield e
+    e.shutdown()
 
 
 #############################################################################################
 # Tests for automated rerouting of method calls to the ExecutionEngine to executor threads
 #############################################################################################
 counter = 1
-class TestDevice(Device):
-    def __init__(self, engine:ExecutionEngine):
-        global counter
-        super().__init__(engine=engine, name=f'mock_device_{counter}', no_executor_attrs=('property_getter_monitor', 'property_setter_monitor'))
-        counter += 1
-        self.property_getter_monitor = False
-        self.property_setter_monitor = False
-        self._test_attribute = None
+class TestDevice:
+    """
+    These classes are automatically wrapped for use in an ExecutionEngine.
+    """
+    def __init__(self):
+        self.test_attribute = None
+        self._test_property = None
 
     def test_method(self):
-        assert ExecutionEngine.on_any_executor_thread()
-        assert threading.current_thread().execution_engine_thread
         return True
-
-    def set_test_attribute(self, value):
-        assert ExecutionEngine.on_any_executor_thread()
-        assert threading.current_thread().execution_engine_thread
-        self._test_attribute = value
-
-    def get_test_attribute(self):
-        assert ExecutionEngine.on_any_executor_thread()
-        assert threading.current_thread().execution_engine_thread
-        return self._test_attribute
 
     @property
     def test_property(self):
-        assert ExecutionEngine.on_any_executor_thread()
-        self.property_getter_monitor = True
-        return self._test_attribute
+        return self._test_property
 
     @test_property.setter
     def test_property(self, value):
-        assert ExecutionEngine.on_any_executor_thread()
-        self.property_setter_monitor = True
-        self._test_attribute = value
+        self._test_property = value
 
 
-def test_device_method_execution(execution_engine):
-    mock_device = TestDevice(execution_engine)
 
-    result = mock_device.test_method()
+def test_device_method_execution(engine):
+    engine.register("mock_device0", TestDevice())
+    result = engine["mock_device0"].test_method().await_execution()
     assert result is True
 
-def test_device_attribute_setting(execution_engine):
-    mock_device = TestDevice(execution_engine)
-
-    mock_device.set_test_attribute("test_value")
-    result = mock_device.get_test_attribute()
+def test_device_attribute_setting(engine):
+    engine.register("mock_device0", TestDevice())
+    engine["mock_device0"].test_attribute = "test_value"
+    result = engine["mock_device0"].test_attribute
     assert result == "test_value"
 
-def test_device_attribute_direct_setting(execution_engine):
-    mock_device = TestDevice(execution_engine)
-
-    mock_device.direct_set_attribute = "direct_test_value"
-    assert mock_device.direct_set_attribute == "direct_test_value"
-
-def test_multiple_method_calls(execution_engine):
-    mock_device = TestDevice(execution_engine)
-
-    result1 = mock_device.test_method()
-    mock_device.set_test_attribute("test_value")
-    result2 = mock_device.get_test_attribute()
+def test_multiple_method_calls(engine):
+    mock_device = engine.register("mock_device0", TestDevice())
+    result1 = mock_device.test_method().await_execution()
+    mock_device.test_attribute = "test_value"
+    result2 = mock_device.test_attribute
 
     assert result1 is True
     assert result2 == "test_value"
 
-def test_device_property_getter(execution_engine):
-    mock_device = TestDevice(execution_engine)
-
-    _ = mock_device.test_property
-    assert mock_device.property_getter_monitor
-
-def test_device_property_setter(execution_engine):
-    mock_device = TestDevice(execution_engine)
-
-    mock_device.test_property = "test_value"
-    assert mock_device.property_setter_monitor
+def test_device_property_setting(engine):
+    mock_device = engine.register("mock_device0", TestDevice())
+    engine["mock_device0"].test_property = "test_value"
+    result = mock_device.test_property
+    assert result == "test_value"
 
 #######################################################
 # Tests for internal threads in Devices
@@ -110,11 +79,8 @@ from exengine.device_types import Device
 import threading
 
 
-class ThreadCreatingDevice(Device):
-    def __init__(self, engine: ExecutionEngine):
-        global counter
-        super().__init__(engine=engine, name=f'test{counter}')
-        counter += 1
+class ThreadCreatingDevice:
+    def __init__(self):
         self.test_attribute = None
         self._internal_thread_result = None
         self._nested_thread_result = None
@@ -157,8 +123,7 @@ class ThreadCreatingDevice(Device):
         with ThreadPoolExecutor() as executor:
             executor.submit(threadpool_func)
 
-@pytest.mark.skip("Currently broken!")
-def test_device_internal_thread(execution_engine):
+def test_device_internal_thread(engine):
     """
     Test that a thread created internally by a device is not treated as an executor thread.
 
@@ -170,17 +135,16 @@ def test_device_internal_thread(execution_engine):
        it ran without raising any assertions about being on an executor thread
     """
     print('integration_tests started')
-    device = ThreadCreatingDevice(execution_engine)
+    engine.register("thread_creator", ThreadCreatingDevice())
     print('getting ready to create internal thread')
-    t = device.create_internal_thread()
+    t = engine["thread_creator"].create_internal_thread().await_execution()
     # t.join()
 
     # while device.test_attribute is None:
     #     time.sleep(0.1)
-    assert device.test_attribute == "set_by_internal_thread"
+    assert engine["thread_creator"].test_attribute == "set_by_internal_thread"
 
-@pytest.mark.skip("Currently broken!")
-def test_device_nested_thread(execution_engine):
+def test_device_nested_thread(engine):
     """
     Test that a nested thread (a thread created by another thread within the device)
     is not treated as an executor thread.
@@ -192,14 +156,13 @@ def test_device_nested_thread(execution_engine):
     3. Checking that the nested thread successfully set an attribute, indicating that
        it ran without raising any assertions about being on an executor thread
     """
-    device = ThreadCreatingDevice(execution_engine)
+    device = engine.register("thread_creator", ThreadCreatingDevice())
     device.create_nested_thread()
     while device.test_attribute is None:
         time.sleep(0.1)
     assert device.test_attribute == "set_by_nested_thread"
 
-@pytest.mark.skip("Currently broken!")
-def test_device_threadpool_executor(execution_engine):
+def test_device_threadpool_executor(engine):
     """
     Test that a thread created by ThreadPoolExecutor within a device method
     is not treated as an executor thread.
@@ -212,7 +175,7 @@ def test_device_threadpool_executor(execution_engine):
     3. Checking that the function successfully set an attribute, indicating that
        it ran without raising any assertions about being on an executor thread
     """
-    device = ThreadCreatingDevice(execution_engine)
+    device = engine.register("thread_creator", ThreadCreatingDevice())
     device.use_threadpool_executor()
     while device.test_attribute is None:
         time.sleep(0.1)
@@ -246,7 +209,7 @@ def create_sync_event(start_event, finish_event):
     return SyncEvent(start_event, finish_event)
 
 
-def test_submit_single_event(execution_engine):
+def test_submit_single_event(engine):
     """
     Test submitting a single event to the ExecutionEngine.
     Verifies that the event is executed and returns an AcquisitionFuture.
@@ -255,8 +218,8 @@ def test_submit_single_event(execution_engine):
     finish_event = threading.Event()
     event = create_sync_event(start_event, finish_event)
 
-    future = execution_engine.submit(event)
-    execution_engine.check_exceptions()
+    future = engine.submit(event)
+    engine.check_exceptions()
     start_event.wait()  # Wait for the event to start executing
     finish_event.set()  # Signal the event to finish
 
@@ -266,7 +229,7 @@ def test_submit_single_event(execution_engine):
     assert event.executed
 
 
-def test_submit_multiple_events(execution_engine):
+def test_submit_multiple_events(engine):
     """
     Test submitting multiple events to the ExecutionEngine.
     Verifies that all events are executed and return AcquisitionFutures.
@@ -279,8 +242,8 @@ def test_submit_multiple_events(execution_engine):
     finish_event2 = threading.Event()
     event2 = create_sync_event(start_event2, finish_event2)
 
-    future1 = execution_engine.submit(event1)
-    future2 = execution_engine.submit(event2)
+    future1 = engine.submit(event1)
+    future2 = engine.submit(event2)
 
     start_event1.wait()  # Wait for the first event to start executing
     finish_event1.set()  # Signal the first event to finish
@@ -294,7 +257,7 @@ def test_submit_multiple_events(execution_engine):
     assert event2.executed
 
 
-def test_event_prioritization(execution_engine):
+def test_event_prioritization(engine):
     """
     Test event prioritization in the ExecutionEngine.
     Verifies that prioritized events are executed before non-prioritized events.
@@ -311,11 +274,11 @@ def test_event_prioritization(execution_engine):
     finish_event3 = threading.Event()
     event3 = create_sync_event(start_event3, finish_event3)
 
-    execution_engine.submit(event1)
+    engine.submit(event1)
     start_event1.wait()  # Wait for the first event to start executing
 
-    execution_engine.submit(event2)
-    execution_engine.submit(event3, prioritize=True)
+    engine.submit(event2)
+    engine.submit(event3, prioritize=True)
 
     finish_event1.set()
     finish_event2.set()
@@ -330,7 +293,7 @@ def test_event_prioritization(execution_engine):
     assert event3.executed
 
 
-def test_use_free_thread_parallel_execution(execution_engine):
+def test_use_free_thread_parallel_execution(engine):
     """
     Test parallel execution using free threads in the ExecutionEngine.
     Verifies that events submitted with use_free_thread=True can execute in parallel.
@@ -343,8 +306,8 @@ def test_use_free_thread_parallel_execution(execution_engine):
     finish_event2 = threading.Event()
     event2 = create_sync_event(start_event2, finish_event2)
 
-    execution_engine.submit(event1)
-    execution_engine.submit(event2, use_free_thread=True)
+    engine.submit(event1)
+    engine.submit(event2, use_free_thread=True)
 
     # Wait for both events to start executing
     assert start_event1.wait(timeout=5)
@@ -365,7 +328,7 @@ def test_use_free_thread_parallel_execution(execution_engine):
     assert event2.executed
 
 
-def test_single_execution_with_free_thread(execution_engine):
+def test_single_execution_with_free_thread(engine):
     """
     Test that each event is executed only once, even when using use_free_thread=True.
     Verifies that events are not executed multiple times regardless of submission method.
@@ -378,8 +341,8 @@ def test_single_execution_with_free_thread(execution_engine):
     finish_event2 = threading.Event()
     event2 = create_sync_event(start_event2, finish_event2)
 
-    execution_engine.submit(event1)
-    execution_engine.submit(event2, use_free_thread=True)
+    engine.submit(event1)
+    engine.submit(event2, use_free_thread=True)
 
     # Wait for both events to start executing
     assert start_event1.wait(timeout=5)
@@ -398,43 +361,43 @@ def test_single_execution_with_free_thread(execution_engine):
     assert event2.execute_count == 1
 
 #### Callable submission tests ####
-def test_submit_callable(execution_engine):
+def test_submit_callable(engine):
     def simple_function():
         return 42
 
-    future = execution_engine.submit(simple_function)
+    future = engine.submit(simple_function)
     result = future.await_execution()
     assert result == 42
 
-def test_submit_lambda(execution_engine):
-    future = execution_engine.submit(lambda: "Hello, World!")
+def test_submit_lambda(engine):
+    future = engine.submit(lambda: "Hello, World!")
     result = future.await_execution()
     assert result == "Hello, World!"
 
-def test_class_method(execution_engine):
+def test_class_method(engine):
     class TestClass:
         def test_method(self):
             return "Test method executed"
 
-    future = execution_engine.submit(TestClass().test_method)
+    future = engine.submit(TestClass().test_method)
     result = future.await_execution()
     assert result == "Test method executed"
 
-def test_submit_mixed(execution_engine):
+def test_submit_mixed(engine):
     class TestEvent(ExecutorEvent):
         def execute(self):
             return "Event executed"
 
-    futures = execution_engine.submit([TestEvent(), lambda: 42, lambda: "Lambda"])
+    futures = engine.submit([TestEvent(), lambda: 42, lambda: "Lambda"])
     results = [future.await_execution() for future in futures]
     assert results == ["Event executed", 42, "Lambda"]
 
-def test_submit_invalid(execution_engine):
+def test_submit_invalid(engine):
     with pytest.raises(TypeError):
-        execution_engine.submit(lambda x: x + 1)  # Callable with arguments should raise TypeError
+        engine.submit(lambda x: x + 1)  # Callable with arguments should raise TypeError
 
     with pytest.raises(TypeError):
-        execution_engine.submit("Not a callable")  # Non-callable, non-ExecutorEvent should raise TypeError
+        engine.submit("Not a callable")  # Non-callable, non-ExecutorEvent should raise TypeError
 
 #######################################################
 # Tests for named thread functionalities ##############
@@ -444,7 +407,7 @@ from exengine.kernel.executor import _MAIN_THREAD_NAME
 from exengine.kernel.executor import _ANONYMOUS_THREAD_NAME
 
 
-def test_submit_to_main_thread(execution_engine):
+def test_submit_to_main_thread(engine):
     """
     Test submitting an event to the main thread.
     """
@@ -452,13 +415,13 @@ def test_submit_to_main_thread(execution_engine):
     finish_event = threading.Event()
     event = create_sync_event(start_event, finish_event)
 
-    future = execution_engine.submit(event)
+    future = engine.submit(event)
     start_event.wait()
     finish_event.set()
 
     assert event.executed_thread_name == _MAIN_THREAD_NAME
 
-def test_submit_to_new_anonymous_thread(execution_engine):
+def test_submit_to_new_anonymous_thread(engine):
     """
     Test that submitting an event with use_free_thread=True creates a new anonymous thread if needed.
     """
@@ -471,11 +434,11 @@ def test_submit_to_new_anonymous_thread(execution_engine):
     event2 = create_sync_event(start_event2, finish_event2)
 
     # Submit first event to main thread
-    execution_engine.submit(event1)
+    engine.submit(event1)
     start_event1.wait()
 
     # Submit second event with use_free_thread=True
-    future2 = execution_engine.submit(event2, use_free_thread=True)
+    future2 = engine.submit(event2, use_free_thread=True)
     start_event2.wait()
 
     finish_event1.set()
@@ -483,9 +446,9 @@ def test_submit_to_new_anonymous_thread(execution_engine):
 
     assert event1.executed_thread_name == _MAIN_THREAD_NAME
     assert event2.executed_thread_name.startswith(_ANONYMOUS_THREAD_NAME)
-    assert len(execution_engine._thread_managers) == 2  # Main thread + 1 anonymous thread
+    assert len(engine._thread_managers) == 2  # Main thread + 1 anonymous thread
 
-def test_multiple_anonymous_threads(execution_engine):
+def test_multiple_anonymous_threads(engine):
     """
     Test creation of multiple anonymous threads when submitting multiple events with use_free_thread=True.
     """
@@ -502,7 +465,7 @@ def test_multiple_anonymous_threads(execution_engine):
         start_events.append(start_event)
         finish_events.append(finish_event)
 
-    futures = [execution_engine.submit(event, use_free_thread=True) for event in events]
+    futures = [engine.submit(event, use_free_thread=True) for event in events]
 
     for start_event in start_events:
         start_event.wait()
@@ -513,9 +476,9 @@ def test_multiple_anonymous_threads(execution_engine):
     thread_names = set(event.executed_thread_name for event in events)
     assert len(thread_names) == num_events  # Each event should be on a different thread
     assert all(name.startswith(_ANONYMOUS_THREAD_NAME) or name == _MAIN_THREAD_NAME for name in thread_names)
-    assert len(execution_engine._thread_managers) == num_events   # num_events anonymous threads
+    assert len(engine._thread_managers) == num_events   # num_events anonymous threads
 
-def test_reuse_named_thread(execution_engine):
+def test_reuse_named_thread(engine):
     """
     Test that submitting multiple events to the same named thread reuses that thread.
     """
@@ -533,7 +496,7 @@ def test_reuse_named_thread(execution_engine):
         start_events.append(start_event)
         finish_events.append(finish_event)
 
-    futures = [execution_engine.submit(event, thread_name=thread_name) for event in events]
+    futures = [engine.submit(event, thread_name=thread_name) for event in events]
 
     for finish_event in finish_events:
         finish_event.set()
@@ -542,4 +505,4 @@ def test_reuse_named_thread(execution_engine):
         start_event.wait()
 
     assert all(event.executed_thread_name == thread_name for event in events)
-    assert len(execution_engine._thread_managers) == 2  # Main thread + 1 custom named thread
+    assert len(engine._thread_managers) == 2  # Main thread + 1 custom named thread

--- a/src/exengine/kernel/test/test_futures.py
+++ b/src/exengine/kernel/test/test_futures.py
@@ -64,7 +64,7 @@ def test_notify_execution_complete(execution_future):
     thread = threading.Thread(target=complete_event)
     thread.start()
     execution_future.await_execution(timeout=5)
-    assert execution_future._event_complete
+    assert execution_future._event_complete.is_set()
 
 
 def test_notify_data(execution_future):

--- a/src/exengine/kernel/test/test_generic_device.py
+++ b/src/exengine/kernel/test/test_generic_device.py
@@ -84,6 +84,11 @@ def test_wrapping(engine):
     engine["object1"].value1 = 7
     assert wrapper.value1 == 7
 
+def test_shutdown(engine):
+    wrapper = engine.register("object1", TestObject())
+    engine.shutdown()
+
+
 def test_device_base_class(engine):
     class T(TestObject, Device):
         def __init__(self, _name, _engine):

--- a/src/exengine/kernel/test/test_generic_device.py
+++ b/src/exengine/kernel/test/test_generic_device.py
@@ -85,6 +85,7 @@ def test_wrapping(engine):
     assert wrapper.value1 == 7
 
 def test_shutdown(engine):
+    "Performs an additional shutdown."
     wrapper = engine.register("object1", TestObject())
     engine.shutdown()
 

--- a/src/exengine/kernel/test/test_generic_device.py
+++ b/src/exengine/kernel/test/test_generic_device.py
@@ -8,7 +8,7 @@ from openwfs.processors import SingleRoi
 import pytest
 
 from exengine import ExecutionEngine
-from exengine.kernel.device import GetAttrEvent, SetAttrEvent, MethodCallEvent
+from exengine.kernel.executor import MethodCallEvent, GetAttrEvent, SetAttrEvent
 from exengine.kernel.ex_future import ExecutionFuture
 
 """
@@ -75,85 +75,24 @@ def test_bare(obj):
 
 def test_wrapping(obj):
     engine = ExecutionEngine()
-    wrapper = register(engine, "object1", obj)
+    wrapper = engine.register("object1", obj)
+    with pytest.raises(AttributeError):
+        wrapper.non_existing_property = 0
     verify_behavior(wrapper)
     engine["object1"].value1 = 7
     assert wrapper.value1 == 7
     engine.shutdown()
 
-class DeviceBase:
-    def __init__(self, wrapped_device):
-        self._device = wrapped_device
 
 
 def test_openwfs():
     img = np.zeros((1000, 1000), dtype=np.int16)
     cam = Camera(StaticSource(img), analog_max=None)
     engine = ExecutionEngine()
-    wrapper = register(engine, "camera1", cam)
+    wrapper = engine.register("camera1", cam)
     future = wrapper.read()
     engine.shutdown()
     frame = future.await_execution()
     assert frame.shape == img.shape
     assert np.all(frame == img)
 
-
-def register(engine: ExecutionEngine, id: str, obj: object):
-    """
-    Wraps an object for use with the ExecutionEngine
-
-    todo: make method of ExecutionEngine?
-
-    The wrapper exposes the public properties and attributes of the wrapped object, converting
-    all get and set access, as well as method calls to Events.
-    Private methods and attributes are not exposed.
-
-    After wrapping, the original object should not be used directly anymore.
-    All access should be done through the wrapper, which takes care of thread safety, synchronization, etc.
-
-    Args:
-        engine: ExecutionEngine instance
-        id: Unique id (name) of the device, used by the ExecutionEngine.
-        obj: object to wrap. The object should only be registered once. Use of the original object should be avoided after wrapping,
-            since access to the original object is not thread safe or otherwise managed by the ExecutionEngine.
-    """
-    #
-    if any(d is obj for d in engine._devices):
-        raise ValueError("Object already registered")
-
-    # get a list of all properties and methods, including the ones in base classes
-    # Also process class annotations, for attributes that are not properties
-    class_hierarchy = inspect.getmro(obj.__class__)
-    all_dict = {}
-    for c in class_hierarchy[::-1]:
-        all_dict.update(c.__dict__)
-        annotations = c.__dict__.get('__annotations__', {})
-        all_dict.update(annotations)
-
-    # create the wrapper class
-    class_dict = {}
-    for name, attribute in all_dict.items():
-        if name.startswith('_'):
-            continue  # skip private attributes
-
-        if inspect.isfunction(attribute):
-            def method(self, *args, _name=name, **kwargs):
-                event = MethodCallEvent(method_name=_name, args=args, kwargs=kwargs, instance=self._device)
-                return engine.submit(event)
-            class_dict[name] = method
-        else:
-            def getter(self, _name=name):
-                event = GetAttrEvent(attr_name=_name, instance=self._device, method=getattr)
-                return engine.submit(event).await_execution()
-            def setter(self, value, _name=name):
-                event = SetAttrEvent(attr_name=_name, value=value, instance=self._device, method=setattr)
-                engine.submit(event).await_execution()
-
-            has_setter = not isinstance(attribute, property) or attribute.fset is not None
-            class_dict[name] = property(getter, setter if has_setter else None, None, f"Wrapped attribute {name}")
-
-    WrappedObject = type('_' + obj.__class__.__name__, (DeviceBase,), class_dict)
-    # todo: cache dynamically generated classes
-    wrapped = WrappedObject(obj)
-    engine.register_device(id, wrapped)
-    return wrapped

--- a/src/exengine/kernel/test/test_generic_device.py
+++ b/src/exengine/kernel/test/test_generic_device.py
@@ -138,11 +138,6 @@ def register(engine: ExecutionEngine, id: str, obj: object):
             has_setter = not isinstance(attribute, property) or attribute.fset is not None
             class_dict[name] = property(getter, setter if has_setter else None, None, f"Wrapped attribute {name}")
 
-        # event = MethodCallEvent(method_name=attr_name, args=args, kwargs=kwargs, instance=self)
-        # return
-        # return ExecutionEngine.get_instance().submit(event, thread_name=thread_name).await_execution()
-        # event = SetAttrEvent(attr_name=name, value=value, instance=self, method=original_setattr)
-        # ExecutionEngine.get_instance().submit(event, thread_name=thread_name).await_execution()
     WrappedObject = type('_' + obj.__class__.__name__, (DeviceBase,), class_dict)
     # todo: cache dynamically generated classes
     wrapped = WrappedObject(obj)

--- a/src/exengine/kernel/test/test_generic_device.py
+++ b/src/exengine/kernel/test/test_generic_device.py
@@ -1,10 +1,14 @@
 import inspect
-import threading
+
+import numpy as np
+import openwfs
+from openwfs.simulation import Camera, StaticSource
+from openwfs.processors import SingleRoi
 
 import pytest
 
 from exengine import ExecutionEngine
-from exengine.kernel.device import Device, GetAttrEvent, SetAttrEvent, MethodCallEvent
+from exengine.kernel.device import GetAttrEvent, SetAttrEvent, MethodCallEvent
 from exengine.kernel.ex_future import ExecutionFuture
 
 """
@@ -83,6 +87,19 @@ def test_wrapping(obj):
 class DeviceBase:
     def __init__(self, wrapped_device):
         self._device = wrapped_device
+
+
+def test_openwfs():
+    img = np.zeros((1000, 1000), dtype=np.int16)
+    cam = Camera(StaticSource(img), analog_max=None)
+    engine = ExecutionEngine()
+    wrapper = register(engine, "camera1", cam)
+    future = wrapper.read()
+    engine.shutdown()
+    frame = future.await_execution()
+    assert frame.shape == img.shape
+    assert np.all(frame == img)
+
 
 def register(engine: ExecutionEngine, id: str, obj: object):
     """

--- a/src/exengine/kernel/test/test_notifications.py
+++ b/src/exengine/kernel/test/test_notifications.py
@@ -32,13 +32,12 @@ def mock_storage():
 @pytest.fixture
 def mock_execution_engine(monkeypatch):
     mock_engine = Mock(spec=ExecutionEngine)
-    monkeypatch.setattr(ExecutionEngine, 'get_instance', lambda: mock_engine)
     return mock_engine
 
 
 @pytest.fixture
 def data_handler(mock_storage, mock_execution_engine):
-    return DataHandler(mock_storage, _executor=mock_execution_engine)
+    return DataHandler(engine=mock_execution_engine, storage=mock_storage)
 
 
 def test_notification_types_inheritance():

--- a/src/exengine/kernel/test/test_queue.py
+++ b/src/exengine/kernel/test/test_queue.py
@@ -1,0 +1,14 @@
+from exengine.kernel.queue import PriorityQueue
+
+
+def test_priority_queue():
+    q = PriorityQueue()
+    q.put((1, "first"))
+    q.put((1, "second"))
+    q.put((1, "third"))
+    q.put((0, "priority"))
+    assert q.get() == (0, "priority")
+    assert q.get() == (1, "first")
+    assert q.get() == (1, "second")
+    assert q.get() == (1, "third")
+    assert q.empty()

--- a/src/tests/test_generic_device.py
+++ b/src/tests/test_generic_device.py
@@ -1,0 +1,136 @@
+import inspect
+
+import pytest
+
+from exengine import ExecutionEngine
+from exengine.kernel.device import Device
+"""
+Tests wrapping a genric object for use with the ExecutionEngine
+"""
+
+class TestObject:
+    """Generic object for testing
+
+    The object has properties with getters and setters, read-only properties, attributes
+    and methods.
+
+    The wrapper exposes the public properties and attributes of the wrapped object, converting
+    all get and set access, as well as method calls to Events.
+    Private methods and attributes are not exposed.
+    """
+    value2: int
+
+    def __init__(self):
+        self._private_attribute = 0
+        self._private_property = 2
+        self.value1 = 3
+        self.value2 = 1
+
+    @property
+    def value1(self):
+        return self._private_property
+
+    @property
+    def readonly_property(self):
+        return -1
+
+    @value1.setter
+    def value1(self, value):
+        self._private_property = value
+
+    def public_method(self, x):
+        return self._private_method(x)
+
+    def _private_method(self, x):
+        return x + self.value1 + self.value2
+
+@pytest.fixture
+def obj():
+    return TestObject()
+
+def test_bare(obj):
+    """Test the non-wrapped object"""
+    obj.value1 = 28
+    obj.value2 = 29
+    assert obj.value1 == 28
+    assert obj.value2 == 29
+    with pytest.raises(AttributeError):
+        obj.readonly_property = 0 # noqa property cannot be set
+    assert obj.readonly_property == -1
+    assert obj.public_method(4) == 28 + 29 + 4
+
+def test_wrapping(obj):
+    engine = ExecutionEngine()
+    wrapper = register(engine, obj)
+    test_bare(wrapper)
+    engine.shutdown()
+
+
+class DeviceBase:
+    def __init__(self, wrapped_device):
+        self._device = wrapped_device
+
+def register(engine: ExecutionEngine, obj: object):
+    """
+    Wraps an object for use with the ExecutionEngine
+
+    todo: make method of ExecutionEngine?
+
+    The wrapper exposes the public properties and attributes of the wrapped object, converting
+    all get and set access, as well as method calls to Events.
+    Private methods and attributes are not exposed.
+
+    After wrapping, the original object should not be used directly anymore.
+    All access should be done through the wrapper, which takes care of thread safety, synchronization, etc.
+    """
+    #
+    if any(d is obj for d in engine._devices):
+        raise ValueError("Object already registered")
+
+    # get a list of all properties and methods, including the ones in base classes
+    # Also process class annotations, for attributes that are not properties
+    class_hierarchy = inspect.getmro(obj.__class__)
+    all_dict = {}
+    for c in class_hierarchy[::-1]:
+        all_dict.update(c.__dict__)
+        annotations = c.__dict__.get('__annotations__', {})
+        all_dict.update(annotations)
+
+    # create the wrapper class
+    class_dict = {
+        '_device': obj,
+    }
+    for n, a in all_dict.items():
+        if n.startswith('_'):
+            continue  # skip private attributes
+        name = n # capture name
+        attribute = a
+        print(name)
+        if inspect.isfunction(attribute):
+            def method(self, *args, _method=attribute, **kwargs):
+                print(f"Calling {_method}")
+                return _method(self._device, *args, **kwargs)
+            class_dict[name] = method
+        #elif isinstance(p, property):
+        #    class_dict[name] = property(p.fget, p.fset, None, p.__doc__)
+        else:
+            def getter(self, _name=name):
+                print(f"Getting {_name}")
+                return getattr(self._device, _name)
+            def setter(self, value, _name=name):
+                print(f"Setting {_name} to {value}")
+                setattr(self._device, _name, value)
+            class_dict[name] = property(getter, setter, None, f"Wrapped attribute {name}")
+        # event = MethodCallEvent(method_name=attr_name, args=args, kwargs=kwargs, instance=self)
+        # return ExecutionEngine.get_instance().submit(event, thread_name=thread_name).await_execution()
+        # todo: use Device as common base class or not at all?
+        # event = GetAttrEvent(attr_name=name, instance=self, method=getattribute_with_fallback)
+        # return ExecutionEngine.get_instance().submit(event, thread_name=thread_name).await_execution()
+        # event = SetAttrEvent(attr_name=name, value=value, instance=self, method=original_setattr)
+        # ExecutionEngine.get_instance().submit(event, thread_name=thread_name).await_execution()
+    WrappedObject = type('_' + obj.__class__.__name__, (DeviceBase,), class_dict)
+    # todo: cache metaclasses
+    wrapped = WrappedObject(obj)
+    print(dir(wrapped))
+    ExecutionEngine.register_device(obj.__class__.__name__, wrapped)
+    return wrapped

--- a/src/tests/test_generic_device.py
+++ b/src/tests/test_generic_device.py
@@ -108,15 +108,11 @@ def register(engine: ExecutionEngine, id: str, obj: object):
         all_dict.update(annotations)
 
     # create the wrapper class
-    class_dict = {
-        '_device': obj,
-    }
-    for n, a in all_dict.items():
-        if n.startswith('_'):
+    class_dict = {}
+    for name, attribute in all_dict.items():
+        if name.startswith('_'):
             continue  # skip private attributes
-        name = n # capture name
-        attribute = a
-        print(name)
+
         if inspect.isfunction(attribute):
             def method(self, *args, _method=attribute, **kwargs):
                 print(f"Calling {_method}")


### PR DESCRIPTION
A completely refactored Device wrapping mechanism, that can wrap openwfs and arbitrary Python objects.

Main changes:
- ExEngine is no longer a singleton class. Each device explictly takes an ExEngine as input to the constructor. Rationale: the singleton antipattern is problematic for testing and scalability. For example: imagine that a client uses two two packages that both use ExEngine. The first package may shut down its own ExEngine at some point. Of course, this should not shut down the other ExEngine. By dropping the singleton pattern this problem is avoided. Moreover, mocking the ExEngine is simpler and it is clear which parts of the code access the engine and which parts do not.

- Device base class and wrapping. ExEngine provides a wrapper that makes attribute access thread safe, converts method calls to delayed execution and (not implemented yet) adds metadata, notifications, etc. To wrap an existing object, call `engine.register`, and make sure never to use the bare (non-wrapped) object. All internal attribute access inside the object itself is unaffected by the wrapper (so no need to monkey patch the threading library). Alternatively, an object can derive from the Device base class. This base class no longer does much, except that it overrides `__new__` to call `engine.register` automatically. Examples are included in test_preferred_thread_annotations.py and test_generic_device.py

- The option to shutdown queues was implemented through condition variables and complicated the code. In Python 3.13, this functionality is natively present in the Queue and PriorityQueue objects. The new code uses these objects when available, and provides a compatible implementation for Python versions < 3.13

Open issues:
- Setting thread affinity is not implemented yet: need to rethink?
- Getting property metadate is not implemented yet: need to rethink the original design with the `get_property_limits` etc.